### PR TITLE
`UiDebugOverlayPlugin` builder

### DIFF
--- a/examples/debug_overlay.rs
+++ b/examples/debug_overlay.rs
@@ -12,7 +12,10 @@ use std::f32::consts::PI;
 
 fn main() {
     App::new()
-        .add_plugins((DefaultPlugins, UiDebugOverlayPlugin))
+        .add_plugins((
+            DefaultPlugins,
+            UiDebugOverlayPlugin::start_enabled().with_line_width(2.),
+        ))
         .add_systems(Startup, (setup, debug_overlay_setup))
         .add_systems(Update, (update_scroll_position, toggle_debug_overlay))
         .run();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 use bevy_app::Plugin;
 use bevy_asset::AssetId;
 use bevy_color::Hsla;
+use bevy_ecs::entity::Entity;
 #[cfg(feature = "bevy_reflect")]
 use bevy_ecs::reflect::ReflectResource;
-use bevy_ecs::entity::Entity;
 use bevy_ecs::system::Commands;
 use bevy_ecs::system::Query;
 use bevy_ecs::system::Res;
@@ -118,13 +118,35 @@ pub fn extract_debug_overlay(
     }
 }
 
-pub struct UiDebugOverlayPlugin;
+#[derive(Default)]
+pub struct UiDebugOverlayPlugin(pub UiDebugOverlay);
+
+impl UiDebugOverlayPlugin {
+    /// Start the app with the debug overlay disabled
+    pub fn start_disabled() -> Self {
+        Default::default()
+    }
+
+    /// Start the app with the debug overlay enabled
+    pub fn start_enabled() -> Self {
+        Self(UiDebugOverlay {
+            enabled: true,
+            ..Default::default()
+        })
+    }
+
+    /// Set the debug overlay's line width in logical pixels
+    pub fn with_line_width(mut self, line_width: f32) -> Self {
+        self.0.line_width = line_width;
+        self
+    }
+}
 
 impl Plugin for UiDebugOverlayPlugin {
     fn build(&self, app: &mut bevy_app::App) {
         #[cfg(feature = "bevy_reflect")]
         app.register_type::<UiDebugOverlay>();
-        app.init_resource::<UiDebugOverlay>();
+        app.insert_resource(UiDebugOverlay { ..self.0 });
 
         if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app.add_systems(ExtractSchedule, extract_debug_overlay);


### PR DESCRIPTION
Makes `UiDebugOverlayPlugin` into a newtype struct wrapping a `UiDebugOverlay`, which is coped into a resource in the plugin's build method.

Adds `start_enabled`, `start_disabled`, and `with_line_width` builder functions to `UiDebugOverlayPlugin`.  

Fixes #2

